### PR TITLE
Add px to rem converter view

### DIFF
--- a/src/devtoolbox.gresource.xml
+++ b/src/devtoolbox.gresource.xml
@@ -60,6 +60,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <file preprocess="xml-stripblanks">ui/views/chmod_calculator.ui</file>
     <file preprocess="xml-stripblanks">ui/views/qrcode_generator.ui</file>
     <file preprocess="xml-stripblanks">ui/views/json_validator.ui</file>
+    <file preprocess="xml-stripblanks">ui/views/px_to_rem_converter.ui</file>
   </gresource>
   <gresource prefix="/me/iepure/devtoolbox/icons/scalable/actions/">
     <file preprocess="xml-stripblanks" alias="non-starred-symbolic.svg">../data/icons/symbolic/non-starred-symbolic.svg</file>

--- a/src/ui/views/px_to_rem_converter.blp
+++ b/src/ui/views/px_to_rem_converter.blp
@@ -1,0 +1,78 @@
+using Gtk 4.0;
+using Adw 1;
+
+template $PxToRemConverterView: Adw.Bin {
+  Adw.ToastOverlay _toast {
+    child: ScrolledWindow {
+      child: Adw.Clamp {
+        vexpand: true;
+        maximum-size: 1200;
+        tightening-threshold: 600;
+
+        child: Box {
+          orientation: vertical;
+
+          $UtilityTitle _title {
+            title: _("PX to REM Converter");
+            description: _("Convert PX units to REM units and vice versa");
+            tool-name: "px-to-rem";
+          }
+
+          Separator {
+            margin-top: 10;
+            margin-bottom: 10;
+          }
+
+          Adw.PreferencesGroup {
+            title: _("Input values");
+
+            $EntryRow _px_entry {
+              title: _("Pixels");
+              input-purpose: "number";
+              text: "16";
+              show-copy-btn: "true";
+              show-clear-btn: "true";
+            }
+
+            $EntryRow _rem_entry {
+              title: _("REM");
+              input-purpose: "number";
+              text: "1";
+              show-copy-btn: "true";
+              show-clear-btn: "true";
+            }
+
+            $EntryRow _root_font_size_entry {
+              title: _("Root Font Size (px)");
+              input-purpose: "number";
+              text: "16";
+              show-copy-btn: "true";
+              show-clear-btn: "true";
+            }
+          }
+
+          Box {
+            orientation: horizontal;
+            halign: center;
+            margin-bottom: 10;
+            margin-top: 10;
+
+            styles [
+              "dim-label",
+            ]
+
+            Image {
+              margin-end: 5;
+              pixel-size: 16;
+              icon-name: "info-symbolic";
+            }
+
+            Label {
+              label: _("Calculation based on a root font-size of 16 pixels.");
+            }
+          }
+        };
+      };
+    };
+  }
+}

--- a/src/views/px_to_rem_converter.py
+++ b/src/views/px_to_rem_converter.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2022 - 2023 Alessandro Iepure
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from gi.repository import Gtk, Adw, GObject
+
+@Gtk.Template(resource_path="/me/iepure/devtoolbox/ui/views/px_to_rem_converter.ui")
+class PxToRemConverterView(Adw.Bin):
+    __gtype_name__ = "PxToRemConverterView"
+
+    # Template elements
+    _px_entry = Gtk.Template.Child()
+    _rem_entry = Gtk.Template.Child()
+    _root_font_size_entry = Gtk.Template.Child()
+
+    def __init__(self):
+        super().__init__()
+
+        # Signals
+        self._px_entry.connect("changed", self._on_px_changed)
+        self._rem_entry.connect("changed", self._on_rem_changed)
+        self._root_font_size_entry.connect("changed", self._on_root_font_size_changed)
+
+    def _on_px_changed(self, user_data: GObject.GPointer):
+        self._convert_px_to_rem()
+
+    def _on_rem_changed(self, user_data: GObject.GPointer):
+        self._convert_rem_to_px()
+
+    def _on_root_font_size_changed(self, user_data: GObject.GPointer):
+        self._convert_px_to_rem()
+
+    def _convert_px_to_rem(self):
+        try:
+            px_value = float(self._px_entry.get_text())
+            root_font_size = float(self._root_font_size_entry.get_text())
+            rem_value = px_value / root_font_size
+            self._rem_entry.set_text(str(rem_value))
+        except ValueError:
+            pass
+
+    def _convert_rem_to_px(self):
+        try:
+            rem_value = float(self._rem_entry.get_text())
+            root_font_size = float(self._root_font_size_entry.get_text())
+            px_value = rem_value * root_font_size
+            self._px_entry.set_text(str(px_value))
+        except ValueError:
+            pass

--- a/src/window.py
+++ b/src/window.py
@@ -36,6 +36,7 @@ from .views.reverse_cron import ReverseCronView
 from .views.chmod_calculator import ChmodCalculatorView
 from .views.qrcode_generator import QRCodeGeneratorView
 from .views.json_validator import JsonValidatorView
+from .views.px_to_rem_converter import PxToRemConverterView
 
 from .formatters.json import JsonFormatter
 from .formatters.sql import SqlFormatter
@@ -151,6 +152,13 @@ class DevtoolboxWindow(Adw.ApplicationWindow):
                 "icon-name": "timer-reverse-symbolic",
                 "tooltip": _("Generate CRON expressions"),
                 "child": ReverseCronView(),
+            },
+            "px-to-rem": {
+                "title": _("PX to REM"),
+                "category": _("Converters"),
+                "icon-name": "horizontal-arrows-symbolic",
+                "tooltip": _("Convert PX units to REM units and vice versa"),
+                "child": PxToRemConverterView(),
             },
 
             # Encoders


### PR DESCRIPTION
Add a new view to convert px units to rem units with an editable root font size.

* Add `PxToRemConverterView` class in `src/views/px_to_rem_converter.py` with input fields for "Pixels", "REM", and "Root Font Size", and implement conversion logic.
* Add UI layout for `PxToRemConverterView` in `src/ui/views/px_to_rem_converter.blp` with input fields, labels, and tooltips.
* Update `src/devtoolbox.gresource.xml` to include the new UI file.
* Update `src/window.py` to include `PxToRemConverterView` in the `_tools` dictionary and the sidebar.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/albrtogarcia/devtoolbox/pull/1?shareId=2a31b686-12a8-4da8-ae7c-cfe6795cab38).